### PR TITLE
Added OTP style modules, so that fprofx can be a rebar dep

### DIFF
--- a/src/fprofx.app.src
+++ b/src/fprofx.app.src
@@ -1,0 +1,13 @@
+{application, fprofx,
+ [
+  {description, "extended fprof"},
+  {vsn, "1"},
+  {registered, []},
+  {applications, [
+                  kernel,
+                  stdlib
+                 ]},
+  {modules, [fprof]},
+  {mod, { fprofx_app, []}},
+  {env, []}
+ ]}.

--- a/src/fprofx_app.erl
+++ b/src/fprofx_app.erl
@@ -1,0 +1,16 @@
+-module(fprofx_app).
+
+-behaviour(application).
+
+%% Application callbacks
+-export([start/2, stop/1]).
+
+%% ===================================================================
+%% Application callbacks
+%% ===================================================================
+
+start(_StartType, _StartArgs) ->
+    fprofx_sup:start_link().
+
+stop(_State) ->
+    fprofx:stop().

--- a/src/fprofx_sup.erl
+++ b/src/fprofx_sup.erl
@@ -1,0 +1,19 @@
+
+-module(fprofx_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+-export([init/1]).
+
+%% ===================================================================
+%% API functions
+%% ===================================================================
+
+start_link() ->
+    fprofx:start().
+
+init(_)-> 
+    {ok,[]}.


### PR DESCRIPTION
rebar dependencies do not work well with modules alone, which are not bundled as an OTP app.

this pull request fixes that. Tested using frofx as a dep, tested using fprofx after adding it to rel/reltool.config.
